### PR TITLE
Add Http.persistent sample in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,18 @@ HTTP.accept(:json).get("https://github.com/httprb/http.rb/commit/HEAD")
 This adds the appropriate Accept header for retrieving a JSON response for the
 given resource.
 
+### Reuse HTTP connection: HTTP Keep-Alive
+
+If you have many successive requests against the same host, you better want to
+reuse the same connection again and again:
+
+```ruby
+contents = []
+targets = %w(Hypertext_Transfer_Protocol Git GitHub Linux Hurd)
+HTTP.persistent('http://en.wikipedia.org').do |http|
+  targets.each { |target| contents << http.get("/wiki/#{target}") }
+end
+```
 
 ### Celluloid::IO Support
 


### PR DESCRIPTION
Being able to reuse HTTP connection is a very valuable feature. It's documented in code, but not in the documentation: even an experimented source reader like me missed it and I had to bother guys on the google group.

A simple sample to say "I exist" will help a lot :)